### PR TITLE
Fix Reference to immortalctl in immortaldir Doc

### DIFF
--- a/post/immortaldir/index.html
+++ b/post/immortaldir/index.html
@@ -55,7 +55,7 @@
 
 <p><code>immortaldir</code> start services located in a specified directory.</p>
 
-<pre><code>immortalctl [dir] [-v]
+<pre><code>immortaldir [dir] [-v]
 </code></pre>
 
 <p><code>immortaldir</code> will scan every 5 seconds a directory searching for files ending in <code>.yml</code> and track changes. The files should conform the <a href="/post/immortal">immortal</a> configuration format.</p>


### PR DESCRIPTION
`immortaldir` documentation from https://immortal.run/post/immortaldir/ refers to a `immortalctl` executable in its usage line which has caused a minor confusion for me. This pull request fixes it with the correct reference for future generations.